### PR TITLE
Feat/user post/#17

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import { companyRouter } from './routers/companyRouter';
+import { userRouter } from './routers/userRouter';
 
 const app: express.Application = express();
 app.use(express.json());
 
 app.use('/companies', companyRouter);
+app.use('/users', userRouter);
 
 app.listen(3000, () => {
   console.log('Server is listening on port 3000');

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from 'express';
+import * as userService from '../services/userService';
+import { CreateUserDTO } from '../dto/userDTO';
+import BadRequestError from '../lib/errors/badRequestError';
+import { create } from 'superstruct';
+
+export const createUser: RequestHandler = async (req, res) => {
+  // Todo: CreateUserBodyStruct 개발 필요
+  const userInput = create(req.body, CreateUserBodyStruct);
+  if (userInput.password !== userInput.passwordConfirmation) {
+    throw new BadRequestError('Password confirmation does not match the password.');
+  }
+  const { passwordConfirmation, ...rest } = userInput;
+  const dto: CreateUserDTO = rest;
+  const user = await userService.createUser(dto);
+  res.status(201).json(user);
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,15 +2,13 @@ import { RequestHandler } from 'express';
 import * as userService from '../services/userService';
 import { CreateUserDTO } from '../dto/userDTO';
 import BadRequestError from '../lib/errors/badRequestError';
-import { create } from 'superstruct';
+import { assert } from 'superstruct';
+import { createUserBodyStruct, registerUserStruct } from '../structs/userStruct';
 
 export const createUser: RequestHandler = async (req, res) => {
-  // Todo: CreateUserBodyStruct 개발 필요
-  const userInput = create(req.body, CreateUserBodyStruct);
-  if (userInput.password !== userInput.passwordConfirmation) {
-    throw new BadRequestError('Password confirmation does not match the password.');
-  }
-  const { passwordConfirmation, ...rest } = userInput;
+  assert(req.body, registerUserStruct);
+  // Todo: 여기서 오류 시 어떤 오류 던지는지, 잘 잡히는지 체크
+  const { passwordConfirmation, ...rest } = req.body;
   const dto: CreateUserDTO = rest;
   const user = await userService.createUser(dto);
   res.status(201).json(user);

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -1,0 +1,15 @@
+import { UserWithCompanyCode } from '../types/userType';
+// Request
+
+export interface CreateUserDTO {
+  name: string;
+  email: string;
+  employeeNumber: string;
+  phoneNumber: string;
+  password: string;
+  company: string;
+  companyCode: string;
+}
+
+// Response
+export type UserResponseDTO = UserWithCompanyCode;

--- a/src/lib/auth/hash.ts
+++ b/src/lib/auth/hash.ts
@@ -1,0 +1,5 @@
+import bcrypt from 'bcrypt';
+
+export async function hashPassword(password: string) {
+  return await bcrypt.hash(password, 10);
+}

--- a/src/lib/errors/conflictError.ts
+++ b/src/lib/errors/conflictError.ts
@@ -1,0 +1,11 @@
+class ConflictError extends Error {
+  status: number;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+    this.status = 409;
+  }
+}
+
+export default ConflictError;

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -12,3 +12,11 @@ export const getWithCompanyCode = async (id: number): Promise<UserWithCompanyCod
     include: { company: { select: { companyCode: true } } },
   });
 };
+
+export const getByEmail = async (email: string): Promise<User | null> => {
+  return await prisma.user.findUnique({ where: { email } });
+};
+
+export const getByEmployeeNumber = async (employeeNumber: string): Promise<User | null> => {
+  return await prisma.user.findUnique({ where: { employeeNumber } });
+};

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -9,7 +9,20 @@ export const create = async (input: CreateUserInput): Promise<User> => {
 export const getWithCompanyCode = async (id: number): Promise<UserWithCompanyCode> => {
   return await prisma.user.findUniqueOrThrow({
     where: { id },
-    include: { company: { select: { companyCode: true } } },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      employeeNumber: true,
+      phoneNumber: true,
+      imageUrl: true,
+      isAdmin: true,
+      company: {
+        select: {
+          companyCode: true,
+        },
+      },
+    },
   });
 };
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,0 +1,14 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { UserWithCompanyCode, User, CreateUserInput } from '../types/userType';
+
+export const create = async (input: CreateUserInput): Promise<User> => {
+  return await prisma.user.create({ data: input });
+};
+
+export const getWithCompanyCode = async (id: number): Promise<UserWithCompanyCode> => {
+  return await prisma.user.findUniqueOrThrow({
+    where: { id },
+    include: { company: { select: { companyCode: true } } },
+  });
+};

--- a/src/routers/userRouter.ts
+++ b/src/routers/userRouter.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 // Todo: withAsync 가져와서 적용
 // Todo: 인증인가 미들웨어 가져와서 적용
+
 import { createUser } from '../controllers/userController';
 
 export const userRouter = express.Router();

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,34 @@
+import { CreateUserDTO, UserResponseDTO } from '../dto/userDTO';
+import * as userRepository from '../repositories/userRepository';
+import * as companyRepository from '../repositories/companyReposiotry'; // companyRepository에서 findValidateCompany잊지않고 만들어야 한다..
+import NotFoundError from '../lib/errors/notFoundError';
+import { hashPassword } from '../lib/auth/hash';
+import ConflictError from '../lib/errors/conflictError';
+import { CreateUserInput } from '../types/userType';
+
+export const createUser = async (dto: CreateUserDTO) => {
+  const { email, employeeNumber, company, companyCode, password, ...rest } = dto;
+  // Refactor? 함수화 : validateCompany
+  const validCompany = await companyRepository.findValidateCompany(company, companyCode);
+  if (!validCompany) {
+    throw new NotFoundError('Company info is invalid.');
+  }
+  const companyId = validCompany.id;
+  // Refactor? 함수화 : checkDuplicateUser
+  const existingEmail = await userRepository.getByEmail(email);
+  const existingEmployeeNumber = await userRepository.getByEmployeeNumber(employeeNumber);
+  if (existingEmail || existingEmployeeNumber) {
+    throw new ConflictError('Email or EmployeeNumber already exists.');
+  }
+  const hashedPassword = await hashPassword(password);
+  const input: CreateUserInput = {
+    ...rest,
+    email,
+    employeeNumber,
+    password: hashedPassword,
+    companyId,
+  };
+  const user = await userRepository.create(input);
+  const userWithCompanyCode: UserResponseDTO = await userRepository.getWithCompanyCode(user.id);
+  return userWithCompanyCode;
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,6 @@
 import { CreateUserDTO, UserResponseDTO } from '../dto/userDTO';
 import * as userRepository from '../repositories/userRepository';
-import * as companyRepository from '../repositories/companyReposiotry'; // companyRepository에서 findValidateCompany잊지않고 만들어야 한다..
+import * as companyRepository from '../repositories/companyRepository'; // companyRepository에서 findValidateCompany잊지않고 만들어야 한다..
 import NotFoundError from '../lib/errors/notFoundError';
 import { hashPassword } from '../lib/auth/hash';
 import ConflictError from '../lib/errors/conflictError';

--- a/src/structs/userStruct.ts
+++ b/src/structs/userStruct.ts
@@ -9,10 +9,17 @@ import {
   defaulted,
   size,
   partial,
+  define,
 } from 'superstruct';
 import { PageParamsStruct } from './commonStruct';
 
 const userSeachKey = ['companyName', 'name', 'email'] as const;
+
+// 조금 더 정교한 형태로 Email 재정의
+const Email = define<string>(
+  'Email',
+  (value) => typeof value === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+);
 
 export const userFilterStruct = object({
   ...PageParamsStruct.schema,
@@ -31,10 +38,11 @@ const password = refine(size(nonempty(string()), 8, 16), 'password', (value) =>
 
 export const createUserBodyStruct = object({
   name: size(nonempty(string()), 1, 10),
-  email: email,
+  email: Email,
   phoneNumber: phoneNumber,
   password: password,
   passwordConfirmation: password,
+  employeeNumber: size(nonempty(string()), 4, 20),
   company: size(nonempty(string()), 1, 30),
   companyCode: size(nonempty(string()), 1, 30),
 });

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -1,0 +1,41 @@
+import { Prisma } from '@prisma/client';
+
+// Entity
+
+export interface User {
+  id: number;
+  companyId: number;
+  name: string;
+  email: string;
+  password: string;
+  employeeNumber: string;
+  phoneNumber: string;
+  imageUrl: string | null;
+  isAdmin: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Types
+
+export interface UserWithCompanyCode {
+  id: number;
+  name: string;
+  email: string;
+  employeeNumber: string;
+  phoneNumber: string;
+  imageUrl: string | null;
+  isAdmin: boolean;
+  company: {
+    companyCode: string;
+  };
+}
+
+export interface CreateUserInput {
+  email: string;
+  employeeNumber: string;
+  password: string;
+  companyId: any;
+  name: string;
+  phoneNumber: string;
+}


### PR DESCRIPTION
#17 

### 요약
- 유저 등록만 우선 구현

### 세부사항
- 검증 (struct, 회사명과 회사코드, 유저중복여부)
- 테스트 하고 잘 작동하는 것 확인했습니다
```
POST http://localhost:3000/users
Content-Type: application/json

{
	"name": "유관순",
	"email": "you@example.com",
	"employeeNumber": "A1234",
	"phoneNumber": "010-1234-0000",
	"password": "password1234",
	"passwordConfirmation": "password1234",
	"company": "새로운 회사",
	"companyCode": "123456"
}
```

### 공용파일 변경점 (merge, pull 시 conflict 날 수 있어요)
- lib의 auth 폴더 만든 후 hashPassword 함수 
- lib Errors에 ConflictError 추가
- app.ts에 userRouter 등록


### 리팩토링 해야할 부분
- service의 로직들을 함수로 묶어서 가독성 높여야 할 듯
