### PR TITLE
차량 조회 기능 구현

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -117,7 +117,7 @@ async function main() {
   await prisma.car.createMany({
     data: [
       {
-        carNumber: '12가1234',
+        carNumber: '12가12345',
         companyId: allCompanies[0].id,
         manufacturerId: kia.id,
         modelId: allModels.find((m) => m.name === 'K5')!.id,
@@ -129,7 +129,7 @@ async function main() {
         accidentDetails: '조수석 범퍼 교체',
       },
       {
-        carNumber: '34나5678',
+        carNumber: '34나56789',
         companyId: allCompanies[1].id,
         manufacturerId: hyundai.id,
         modelId: allModels.find((m) => m.name === 'Sonata')!.id,
@@ -141,7 +141,7 @@ async function main() {
         accidentDetails: '뒤 범퍼, 도장',
       },
       {
-        carNumber: '56다9012',
+        carNumber: '56다90123',
         companyId: allCompanies[2].id,
         manufacturerId: tesla.id,
         modelId: allModels.find((m) => m.name === 'Model 3')!.id,

--- a/src/controllers/carController.ts
+++ b/src/controllers/carController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import * as carService from '../services/carService';
-import { createCarBodyStruct, updateCarBodyStruct } from '../structs/carStruct';
+import { carFilterStruct, createCarBodyStruct, updateCarBodyStruct } from '../structs/carStruct';
 import { create } from 'superstruct';
+import { SearchField } from '../dto/carDTO';
 
 export const registerCar = async (req: Request, res: Response): Promise<void> => {
   const data = create(req.body, createCarBodyStruct);
@@ -13,7 +14,7 @@ export const registerCar = async (req: Request, res: Response): Promise<void> =>
   // }
   // const companyId = (req.user as { companyId: number }).companyId;
 
-  const companyId = 3; // 임시로 companyId 지정
+  const companyId = 10; // 임시로 companyId 지정
 
   if (!companyId) throw new Error('companyId는 필수입니다.');
 
@@ -32,7 +33,7 @@ export const updateCar = async (req: Request, res: Response): Promise<void> => {
   // }
   // const companyId = (req.user as { companyId: number }).companyId;
 
-  const companyId = 3; // 임시로 companyId 지정
+  const companyId = 10; // 임시로 companyId 지정
 
   if (!companyId) throw new Error('companyId는 필수입니다.');
   const updatedCar = await carService.updateCar(Number(id), data, companyId);
@@ -47,6 +48,20 @@ export const deleteCar = async (req: Request, res: Response): Promise<void> => {
 };
 
 export const getCarList = async (req: Request, res: Response): Promise<void> => {
-  const carList = await carService.getCarList();
-  res.status(200).json(carList);
+  const { page, pageSize, searchBy, keyword } = create(req.query, carFilterStruct);
+
+  const carList = await carService.getCarList({
+    page,
+    pageSize,
+    searchBy: searchBy as SearchField,
+    keyword,
+  });
+
+  res.status(200).json({
+    // 별도 과정없이 직관적으로 정보를 확인하기 좋아서 권장됨...
+    totalCount: carList.totalCount,
+    page,
+    pageSize,
+    cars: carList.cars,
+  });
 };

--- a/src/dto/carDTO.ts
+++ b/src/dto/carDTO.ts
@@ -5,7 +5,6 @@ export function fromEnumStyle(value: string): string {
 }
 
 export interface carRegistUpdateDTO {
-  id: number;
   carNumber: string;
   manufacturer: string;
   model: string;
@@ -20,7 +19,6 @@ export interface carRegistUpdateDTO {
 }
 
 export function mapCarDTO(car: {
-  id: number;
   carNumber: string;
   manufacturer: { name: string };
   model: { name: string; type: string };
@@ -33,7 +31,6 @@ export function mapCarDTO(car: {
   accidentDetails: string | null;
 }): carRegistUpdateDTO {
   return {
-    id: car.id,
     carNumber: car.carNumber,
     manufacturer: car.manufacturer.name,
     model: car.model.name,

--- a/src/dto/carDTO.ts
+++ b/src/dto/carDTO.ts
@@ -1,10 +1,12 @@
 import { CarStatus } from '@prisma/client';
+import { GetCompanyListDTO } from './companyDto';
 
 export function fromEnumStyle(value: string): string {
   return value.toLowerCase().replace(/_([a-z])/g, (_, g) => g.toUpperCase());
 }
 
 export interface carRegistUpdateDTO {
+  id: number;
   carNumber: string;
   manufacturer: string;
   model: string;
@@ -19,6 +21,7 @@ export interface carRegistUpdateDTO {
 }
 
 export function mapCarDTO(car: {
+  id: number;
   carNumber: string;
   manufacturer: { name: string };
   model: { name: string; type: string };
@@ -31,6 +34,7 @@ export function mapCarDTO(car: {
   accidentDetails: string | null;
 }): carRegistUpdateDTO {
   return {
+    id: car.id,
     carNumber: car.carNumber,
     manufacturer: car.manufacturer.name,
     model: car.model.name,
@@ -56,4 +60,11 @@ export interface CarRegisterRequestDTO {
   accidentCount: number;
   explanation?: string | null;
   accidentDetails?: string | null;
+}
+
+export type SearchField = 'carNumber' | 'model';
+
+export interface GetCarListDTO extends GetCompanyListDTO {
+  // 현재 사용되는 DTO이용, 나중에 중복코드 리팩토링 시 변경?!
+  searchBy?: SearchField;
 }

--- a/src/services/carService.ts
+++ b/src/services/carService.ts
@@ -1,6 +1,6 @@
 import * as carRepository from '../repositories/carRepository';
 import { CarType } from '../types/carType';
-import { CarRegisterRequestDTO, carRegistUpdateDTO, mapCarDTO } from '../dto/carDTO';
+import { CarRegisterRequestDTO, carRegistUpdateDTO, GetCarListDTO, mapCarDTO } from '../dto/carDTO';
 import NotFoundError from '../lib/errors/notFoundError';
 import { mapCarStatus } from '../structs/carStruct';
 
@@ -104,7 +104,26 @@ export async function deleteCar(id: number): Promise<void> {
   await carRepository.deleteCar(id);
 }
 
-export async function getCarList() {
-  const cars = await carRepository.getCarList();
-  return cars.map(carResponseDTO);
+export async function getCarList(
+  data: GetCarListDTO,
+): Promise<{ totalCount: number; cars: carRegistUpdateDTO[] }> {
+  const { totalCount, carList } = await carRepository.getCarList(data);
+
+  const cars = carList.map((car) =>
+    mapCarDTO({
+      ...car,
+      manufacturer: {
+        name: car.model.manufacturer.name,
+      },
+      model: {
+        name: car.model.name,
+        type: car.model.type,
+      },
+    }),
+  );
+
+  return {
+    totalCount,
+    cars,
+  };
 }

--- a/src/structs/carStruct.ts
+++ b/src/structs/carStruct.ts
@@ -41,7 +41,7 @@ export const carFilterStruct = object({
 export type CarFilter = Infer<typeof carFilterStruct>;
 
 export const createCarBodyStruct = object({
-  carNumber: size(nonempty(string()), 8, 30),
+  carNumber: size(nonempty(string()), 7, 8),
   manufacturer: nonempty(string()),
   model: nonempty(string()),
   manufacturingYear: max(min(integer(), 1975), 2025),


### PR DESCRIPTION
#36 
## 내용
등록된 차량 조회 기능 구현
- 페이지네이션 가능
- 차량번호, 차종(모델)로 검색 필터 적용
carNumber 자리수 범위 7~8자리로 struct 수정

## 수정된 파일
- src/controllers/carController.ts
- src/dto/carDTO.ts
- src/repositories/carRepository.ts
- src/services/carService.ts  
- src/structs/carStruct.ts

## TEST 방법 예시

###Car 조회 (carNumber로 조회)
GET http://localhost:3000/cars?page=1&pageSize=10&searchBy=carNumber&keyword=12가

###Car 조회 (carModel로 조회)
GET http://localhost:3000/cars?page=1&pageSize=10&searchBy=model&keyword=Avante

## 새로 알게된 내용
controller에서 res.json 할 때 아래와 같은 방법으로 구현하면 
별도의 과정없이 직관적으로 정보를 확인하기 좋아서 (현업에서) 많이 사용되어 권장된다고 합니다. 

```javascript
res.status(200).json({
    totalCount: carList.totalCount,
    page,
    pageSize,
    cars: carList.cars,
  });
```

<div align=center><img width="230" alt="스크린샷 2025-04-23 00 47 51" src="https://github.com/user-attachments/assets/4a16070a-575f-4e8c-8fdf-5f783b59df4f" />
<img width="230" alt="스크린샷 2025-04-23 00 47 25" src="https://github.com/user-attachments/assets/672c547e-4fad-45b7-9b6f-f1db53c3c682" /></div>


## 앞으로 할 일
중복되는 Params DTO를 정리하면 이에 따른 차량 조회에 관련된 DTO 수정
