### PR TITLE
Feat/auth/#53 : 인증인가 미들웨어 

### DIFF
--- a/src/controllers/errorController.ts
+++ b/src/controllers/errorController.ts
@@ -35,7 +35,7 @@ export function globalErrorHandler(
   }
 
   if (err instanceof UnauthorizedError) {
-    res.status(401).send({ message: 'Internal serveer error' });
+    res.status(401).send({ message: err.message });
     return;
   }
 

--- a/src/dto/companyDto.ts
+++ b/src/dto/companyDto.ts
@@ -25,6 +25,7 @@ export class CompanyResponseDTO {
     this.id = company.id;
     this.companyName = company.companyName;
     this.companyCode = company.companyCode;
+
     this.userCount =
       '_count' in company && company._count?.users !== undefined ? company._count.users : 0;
   }

--- a/src/middlewares/requireAdmin.ts
+++ b/src/middlewares/requireAdmin.ts
@@ -4,7 +4,10 @@ import UnauthorizedError from '../lib/errors/unauthorizedError';
 import * as userRepository from '../repositories/userRepository';
 
 export const requireAdmin: RequestHandler = asyncHandler(async (req, res, next) => {
-  const userId = req.user!.userId;
+  const userId = req.user?.userId;
+  if (!userId) {
+    throw new UnauthorizedError('담당자만 가능합니다.');
+  }
   const user = await userRepository.getById(userId);
   if (!user.isAdmin) {
     throw new UnauthorizedError('담당자만 가능합니다.');

--- a/src/middlewares/requireAdmin.ts
+++ b/src/middlewares/requireAdmin.ts
@@ -1,0 +1,13 @@
+import { RequestHandler } from 'express';
+import { asyncHandler } from '../lib/async-handler';
+import UnauthorizedError from '../lib/errors/unauthorizedError';
+import * as userRepository from '../repositories/userRepository';
+
+export const requireAdmin: RequestHandler = asyncHandler(async (req, res, next) => {
+  const userId = req.user!.userId;
+  const user = await userRepository.getById(userId);
+  if (!user.isAdmin) {
+    throw new UnauthorizedError('담당자만 가능합니다.');
+  }
+  return next();
+});

--- a/src/middlewares/verifyAccessToken.ts
+++ b/src/middlewares/verifyAccessToken.ts
@@ -1,0 +1,13 @@
+import { expressjwt } from 'express-jwt';
+import { Secret } from 'jsonwebtoken';
+
+export const verifyAccessToken = expressjwt({
+  secret: process.env.JWT_SECRET as Secret,
+  algorithms: ['HS256'],
+  requestProperty: 'user',
+  getToken: (req) => {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.split(' ')[1];
+    return token;
+  },
+});

--- a/src/middlewares/verifyRefreshToken.ts
+++ b/src/middlewares/verifyRefreshToken.ts
@@ -1,0 +1,9 @@
+import { expressjwt } from 'express-jwt';
+import { Secret } from 'jsonwebtoken';
+
+export const verifyRefreshToken = expressjwt({
+  secret: process.env.JWT_SECRET as Secret,
+  algorithms: ['HS256'],
+  requestProperty: 'user',
+  getToken: (req) => req.body.refreshToken,
+});

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -85,3 +85,7 @@ export const findForLoginByEmail = async (
   });
   return user;
 };
+
+export const getById = async (id: number): Promise<User> => {
+  return await prisma.user.findUniqueOrThrow({ where: { id } });
+};

--- a/src/routers/companyRouter.ts
+++ b/src/routers/companyRouter.ts
@@ -6,10 +6,12 @@ import {
   updateCompany,
   deleteCompany,
 } from '../controllers/companyController';
+import { verifyAccessToken } from '../middlewares/verifyAccessToken';
+import { requireAdmin } from '../middlewares/requireAdmin';
 // Todo: withAsync
 // Todo: 인증인가 미들웨어들
 export const companyRouter = express.Router();
 
-companyRouter.route('/').post(createCompany).get(getCompanyList);
+companyRouter.route('/').post(verifyAccessToken, requireAdmin, createCompany).get(getCompanyList);
 companyRouter.get('/users/', getUserList);
 companyRouter.route('/:id').patch(updateCompany).delete(deleteCompany);

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -3,7 +3,7 @@ import { User } from '@prisma/client';
 declare global {
   namespace Express {
     interface Request {
-      user?: Pick<User, 'id' | 'companyId'>;
+      user?: { userId: number; companyId: number };
     }
   }
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,9 +1,12 @@
-import { User } from '@prisma/client';
+import Express from 'express';
 
 declare global {
   namespace Express {
     interface Request {
-      user?: { userId: number; companyId: number };
+      user?: {
+        userId: number;
+        companyId: number;
+      };
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,10 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "typeRoots": [
+      "./node_modules/@types",
+      "./src/types"
+    ] /* Specify multiple folders that act like './node_modules/@types'. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/types/**/*"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -34,8 +34,8 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [
-      "./node_modules/@types",
-      "./src/types"
+      "src/types",
+      "node_modules/@types"
     ] /* Specify multiple folders that act like './node_modules/@types'. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
#53 

## 요약
- verifyAccessToken : 요청에 토큰이 잘 왔다면 확인하고 userId랑 companyId를 req.user에 넣어줍니다
- verifyRefreshToken: 마찬가지인데 리프레시 토큰인것
- requireAdmin : req.user의 userId로 검색해봤을 때 admin 이면 통과시켜줍니다

## 유의사항
- tsconfig 도 건드리고, express.d.ts도 건드리고 공용파일을 좀 건드렸습니다 conflict 주의!
## 사용방법
- 로그인 해야 하는 경우에는 router에서 verifyAccessToken 을 미들웨어로 껴주세요!
- 관리자만 할 수 있는 경우에는 verifyAccessToken 다음에 requireAdmin도 껴주세요! 
- 예시는 companyRouter 에 있습니다

### 실제 테스트 할 때
- 로그인을 하면 accessToken과 refreshToken을 res.body로 내려줍니다. 그중 accesesToken을 복사하세요
- 다음 request 때 Authorization: Bearer <복사한 accessToken> 을 붙여서 보내주시면 됩니다
---
**예시** 
- 유저 등록 -> 유저 로그인 -> 받은 accessToken을 다른 리퀘스트에 복붙
- 이 세개의 과정이 모두 필요합니다..!

```
### 유저 등록

POST http://localhost:3000/users
Content-Type: application/json

{
	"name": "유관순",
	"email": "you@example.com",
	"employeeNumber": "A1234",
	"phoneNumber": "010-1234-0000",
	"password": "password1234",
	"passwordConfirmation": "password1234",
	"company": "오토랜드",
	"companyCode": "AUTO456"
}


### 유저 로그인
POST http://localhost:3000/auth/login
Content-Type: application/json

{"email": "you@example.com",
"password": "password1234"}

### 회사 등록
POST http://localhost:3000/companies
Content-Type: application/json
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjQsImNvbXBhbnlJZCI6MiwiaWF0IjoxNzQ1Mzg3OTExLCJleHAiOjE3NDUzOTE1MTF9.jjLO8A-otwY7hy5kuhRxg_GyDcySVILmor9MU8NIOME

{
  "companyName": "중고차회사요~",
  "companyCode": "123123"
}
```