### PR TITLE
feat/customers/#39 석기현 ENUM 변환

### DIFF
--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import * as customerService from '../services/customerService';
-import NotFoundError from '../lib/errors/notFoundError';
 
 export const createCustomerHandler = async (req: Request, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
@@ -18,11 +17,9 @@ export const updateCustomerHandler = async (req: Request, res: Response) => {
 export const deleteCustomerHandler = async (req: Request, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const customerId = Number(req.params.id);
-  const result = await customerService.deleteCustomer(customerId, companyId);
 
-  await customerService.deleteCustomer(customerId, companyId); // ✅ 수정: 에러 처리는 서비스에서
-
-  res.status(200).json({ message: '고객 삭제 성공' }); // ✅ 수정: 성공 응답만
+  await customerService.deleteCustomer(customerId, companyId);
+  res.status(200).json({ message: '고객 삭제 성공' });
 };
 
 export const getCustomersHandler = async (req: Request, res: Response) => {

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -1,12 +1,100 @@
 import * as customerRepo from '../repositories/customerRepository';
 import { CreateCustomerDTO, UpdateCustomerDTO } from '../dto/customer.dto';
-import { Prisma } from '@prisma/client';
+import { Gender, AgeGroup, Region, Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import NotFoundError from '../lib/errors/notFoundError';
 import { getCustomers } from '../repositories/customerRepository';
+import { ageGroupToLabel, regionToLabel, genderToLabel } from '../types/customerType';
+
+function toGenderEnum(label: string): Gender {
+  switch (label) {
+    case '남성':
+      return 'MALE';
+    case '여성':
+      return 'FEMALE';
+    default:
+      throw new Error(`gender 변환 실패: ${label}`);
+  }
+}
+
+function toAgeGroupEnum(label?: string): AgeGroup | undefined {
+  switch (label) {
+    case '10대':
+      return 'TEENAGER';
+    case '20대':
+      return 'TWENTIES';
+    case '30대':
+      return 'THIRTIES';
+    case '40대':
+      return 'FORTIES';
+    case '50대':
+      return 'FIFTIES';
+    case '60대':
+      return 'SIXTIES';
+    case '70대':
+      return 'SEVENTIES';
+    case '80대':
+      return 'EIGHTIES';
+    case undefined:
+      return undefined;
+    default:
+      throw new Error(`ageGroup 변환 실패: ${label}`);
+  }
+}
+
+function toRegionEnum(label?: string): Region | undefined {
+  switch (label) {
+    case '서울':
+      return 'SEOUL';
+    case '경기':
+      return 'GYEONGGI';
+    case '인천':
+      return 'INCHEON';
+    case '강원':
+      return 'GANGWON';
+    case '충북':
+      return 'CHUNGBUK';
+    case '충남':
+      return 'CHUNGNAM';
+    case '세종':
+      return 'SEJONG';
+    case '대전':
+      return 'DAEJEON';
+    case '전북':
+      return 'JEONBUK';
+    case '전남':
+      return 'JEONNAM';
+    case '광주':
+      return 'GWANGJU';
+    case '경북':
+      return 'GYEONGBUK';
+    case '경남':
+      return 'GYEONGNAM';
+    case '대구':
+      return 'DAEGU';
+    case '울산':
+      return 'ULSAN';
+    case '부산':
+      return 'BUSAN';
+    case '제주':
+      return 'JEJU';
+    case undefined:
+      return undefined;
+    default:
+      throw new Error(`region 변환 실패: ${label}`);
+  }
+}
 
 export const createCustomer = (companyId: number, data: CreateCustomerDTO) => {
-  return customerRepo.createCustomer(companyId, data as Prisma.CustomerUncheckedCreateInput);
+  const prismaData: Prisma.CustomerUncheckedCreateInput = {
+    ...data,
+    companyId,
+    gender: toGenderEnum(data.gender),
+    ageGroup: toAgeGroupEnum(data.ageGroup),
+    region: toRegionEnum(data.region),
+  };
+
+  return customerRepo.createCustomer(companyId, prismaData);
 };
 
 export const updateCustomer = async (
@@ -55,10 +143,18 @@ export const getCustomersService = async (
 
   const totalPages = Math.ceil(totalCount / pageSize);
 
+  //Enum to Label로 변환
+  const parsedCustomers = customers.map((customer) => ({
+    ...customer,
+    gender: genderToLabel[customer.gender],
+    ageGroup: customer.ageGroup ? ageGroupToLabel[customer.ageGroup] : null,
+    region: customer.region ? regionToLabel[customer.region] : null,
+  }));
+
   return {
     currentPage: page,
     totalPages,
     totalItemCount: totalCount,
-    data: customers,
+    data: parsedCustomers,
   };
 };

--- a/src/types/customerType.ts
+++ b/src/types/customerType.ts
@@ -1,0 +1,56 @@
+export type GenderLabel = '남성' | '여성';
+export type AgeGroupLabel = '10대' | '20대' | '30대' | '40대' | '50대' | '60대' | '70대' | '80대';
+export type RegionLabel =
+  | '서울'
+  | '경기'
+  | '인천'
+  | '강원'
+  | '충북'
+  | '충남'
+  | '세종'
+  | '대전'
+  | '전북'
+  | '전남'
+  | '광주'
+  | '경북'
+  | '경남'
+  | '대구'
+  | '울산'
+  | '부산'
+  | '제주';
+
+export const genderToLabel = {
+  MALE: '남성',
+  FEMALE: '여성',
+};
+
+export const ageGroupToLabel = {
+  TEENAGER: '10대',
+  TWENTIES: '20대',
+  THIRTIES: '30대',
+  FORTIES: '40대',
+  FIFTIES: '50대',
+  SIXTIES: '60대',
+  SEVENTIES: '70대',
+  EIGHTIES: '80대',
+};
+
+export const regionToLabel = {
+  SEOUL: '서울',
+  GYEONGGI: '경기',
+  INCHEON: '인천',
+  GANGWON: '강원',
+  CHUNGBUK: '충북',
+  CHUNGNAM: '충남',
+  SEJONG: '세종',
+  DAEJEON: '대전',
+  JEONBUK: '전북',
+  JEONNAM: '전남',
+  GWANGJU: '광주',
+  GYEONGBUK: '경북',
+  GYEONGNAM: '경남',
+  DAEGU: '대구',
+  ULSAN: '울산',
+  BUSAN: '부산',
+  JEJU: '제주',
+};


### PR DESCRIPTION
#39 
# 주요 내용
- 원래는 매핑 후 역매핑을 하는 방법이 있다고 하여 그러한 방식을 사용하려고 하였으나 에러도 많이 뜨고 도저히 모르겠어서 ENUM과 Service 코드 내에 LABEL을 정의해 서로 상호작용하는 형식으로 구성해보았습니다.
- 최종적으로 ENUM은 유지하되 Service 부분에서 한글 LABEL과 ENUM간 변환 처리 방식을 사용.

# 구조
생성 > LABEL값을 ENUM값으로 저장 (프론트에서 남성으로 저장된 값을 백엔드에선 MALE로 저장)
조회 > ENUM값을 LABEL으로 변환 (반대로 백엔드에서 MALE값을 한글로 변환 후 응답)
Prisma DB에는 영어 Enum 저장

# 커밋 내용
fixed file: customerController.ts, customerService.ts
added file: customerType.ts