### PR TITLE
Feat/내 정보 수정하기

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -6,6 +6,7 @@ import {
   LoginDTO,
   RefreshTokenDTO,
   RefreshTokenResponseDTO,
+  updateMyInfoDTO,
   UserProfileDTO,
 } from '../dto/userDTO';
 import BadRequestError from '../lib/errors/badRequestError';
@@ -14,6 +15,7 @@ import {
   loginBodyStruct,
   refreshTokenBodyStruct,
   registerUserStruct,
+  updateUserBodyStruct,
   userFilterStruct,
 } from '../structs/userStruct';
 import NotFoundError from '../lib/errors/notFoundError';
@@ -54,5 +56,20 @@ export const getMyInfo = async (req: Request, res: Response): Promise<void> => {
   }
   const { userId } = req.user;
   const user: UserProfileDTO = await userService.getMyInfo(userId);
+  res.status(200).json(user);
+};
+
+export const updateMyInfo = async (req: Request, res: Response): Promise<void> => {
+  assert(req.body, updateUserBodyStruct);
+  if (req.body.password !== req.body.passwordConfirmation) {
+    throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다');
+  }
+  const { passwordConfirmation, ...rest } = req.body;
+  const data: updateMyInfoDTO = rest;
+  if (!req.user) {
+    throw new UnauthorizedError('로그인이 필요합니다');
+  }
+  const { userId } = req.user;
+  const user: UserProfileDTO = await userService.updateMyInfo(userId, data);
   res.status(200).json(user);
 };

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -30,10 +30,11 @@ export interface RefreshTokenDTO {
 }
 
 export interface updateMyInfoDTO {
-  employeeNumber?: string;
+  employeeNumber: string;
   currentPassword: string;
+  phoneNumber: string;
   password?: string;
-  imageUrl?: string;
+  imageUrl: string | null;
 }
 
 // Response

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -31,6 +31,7 @@ export interface RefreshTokenDTO {
 
 export interface updateMyInfoDTO {
   employeeNumber?: string;
+  currentPassword: string;
   password?: string;
   imageUrl?: string;
 }

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -29,6 +29,12 @@ export interface RefreshTokenDTO {
   refreshToken: string;
 }
 
+export interface updateMyInfoDTO {
+  employeeNumber?: string;
+  password?: string;
+  imageUrl?: string;
+}
+
 // Response
 export type UserResponseDTO = UserWithCompanyCode;
 

--- a/src/routers/userRouter.ts
+++ b/src/routers/userRouter.ts
@@ -2,10 +2,10 @@ import express from 'express';
 // Todo: withAsync 가져와서 적용
 // Todo: 인증인가 미들웨어 가져와서 적용
 
-import { createUser, getMyInfo } from '../controllers/userController';
+import { createUser, getMyInfo, updateMyInfo } from '../controllers/userController';
 import { verifyAccessToken } from '../middlewares/verifyAccessToken';
 
 export const userRouter = express.Router();
 
 userRouter.post('/', createUser);
-userRouter.get('/me', verifyAccessToken, getMyInfo);
+userRouter.route('/me').get(verifyAccessToken, getMyInfo).patch(verifyAccessToken, updateMyInfo);

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -6,6 +6,7 @@ import {
   LoginResponseDTO,
   RefreshTokenDTO,
   RefreshTokenResponseDTO,
+  updateMyInfoDTO,
   UserProfileDTO,
   UserResponseDTO,
 } from '../dto/userDTO';
@@ -95,4 +96,18 @@ export const refreshToken = async (dto: RefreshTokenDTO): Promise<RefreshTokenRe
 export const getMyInfo = async (userId: number): Promise<UserProfileDTO> => {
   const userProfile: UserProfileDTO = await userRepository.getWithCompanyCode(userId);
   return userProfile;
+};
+
+export const updateMyInfo = async (
+  userId: number,
+  data: updateMyInfoDTO,
+): Promise<UserProfileDTO> => {
+  const { currentPassword, ...dataWithoutCurrentPassword } = data;
+  const user = await userRepository.getById(userId);
+  const isValidPassword = await bcrypt.compare(currentPassword, user.password);
+  if (!isValidPassword) {
+    throw new BadRequestError('현재 비밀번호가 맞지 않습니다');
+  }
+  const updated = await userRepository.updateAndGetUser(userId, dataWithoutCurrentPassword);
+  return updated;
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -103,11 +103,16 @@ export const updateMyInfo = async (
   data: updateMyInfoDTO,
 ): Promise<UserProfileDTO> => {
   const { currentPassword, ...dataWithoutCurrentPassword } = data;
-  const user = await userRepository.getById(userId);
-  const isValidPassword = await bcrypt.compare(currentPassword, user.password);
-  if (!isValidPassword) {
-    throw new BadRequestError('현재 비밀번호가 맞지 않습니다');
+  if (data.password) {
+    const user = await userRepository.getById(userId);
+    const isValidPassword = await bcrypt.compare(currentPassword, user.password);
+    if (!isValidPassword) {
+      throw new BadRequestError('현재 비밀번호가 맞지 않습니다');
+    }
+    const hashedPassword = await hashPassword(data.password);
+    dataWithoutCurrentPassword.password = hashedPassword;
   }
+
   const updated = await userRepository.updateAndGetUser(userId, dataWithoutCurrentPassword);
   return updated;
 };

--- a/src/structs/userStruct.ts
+++ b/src/structs/userStruct.ts
@@ -8,6 +8,7 @@ import {
   size,
   partial,
   define,
+  nullable,
 } from 'superstruct';
 import { PageParamsStruct } from './commonStruct';
 
@@ -47,12 +48,12 @@ export const registerUserStruct = refine(createUserBodyStruct, 'passwordsMatch',
 });
 
 export const updateUserBodyStruct = object({
-  employeeNumber: optional(size(string(), 4, 20)),
-  phoneNumber: optional(phoneNumber),
+  employeeNumber: size(string(), 4, 20),
+  phoneNumber: phoneNumber,
   currentPassword: password,
   password: optional(password),
   passwordConfirmation: optional(password),
-  imageUrl: optional(string()),
+  imageUrl: nullable(string()),
 });
 
 // export const updateUserStruct = refine(updateUserBodyStruct, 'passwordMatch', (value) => {

--- a/src/structs/userStruct.ts
+++ b/src/structs/userStruct.ts
@@ -55,9 +55,9 @@ export const updateUserBodyStruct = object({
   imageUrl: optional(string()),
 });
 
-export const updateUserStruct = refine(updateUserBodyStruct, 'passwordMatch', (value) => {
-  return value.password === value.passwordConfirmation;
-});
+// export const updateUserStruct = refine(updateUserBodyStruct, 'passwordMatch', (value) => {
+//   return value.password === value.passwordConfirmation;
+// });
 
 export const loginBodyStruct = object({
   email: Email,

--- a/src/structs/userStruct.ts
+++ b/src/structs/userStruct.ts
@@ -46,7 +46,18 @@ export const registerUserStruct = refine(createUserBodyStruct, 'passwordsMatch',
   return value.password === value.passwordConfirmation;
 });
 
-export const updateUserBodyStruct = partial(createUserBodyStruct);
+export const updateUserBodyStruct = object({
+  employeeNumber: optional(size(string(), 4, 20)),
+  phoneNumber: optional(phoneNumber),
+  currentPassword: password,
+  password: optional(password),
+  passwordConfirmation: optional(password),
+  imageUrl: optional(string()),
+});
+
+export const updateUserStruct = refine(updateUserBodyStruct, 'passwordMatch', (value) => {
+  return value.password === value.passwordConfirmation;
+});
 
 export const loginBodyStruct = object({
   email: Email,

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -66,7 +66,8 @@ export interface TokenPayload {
 }
 
 export interface updateMyInfoInput {
-  employeeNumber?: string;
+  employeeNumber: string;
+  phoneNumber: string;
   password?: string;
-  imageUrl?: string;
+  imageUrl: string | null;
 }

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -64,3 +64,9 @@ export interface TokenPayload {
   userId: number;
   companyId: number;
 }
+
+export interface updateMyInfoInput {
+  employeeNumber?: string;
+  password?: string;
+  imageUrl?: string;
+}


### PR DESCRIPTION
나의 정보 수정입니다..

- req.user의 정보로 내 정보를 수정하기
- currentPassword가 DB의 비번과 맞아야 합니다 (service 에서 검증)
- password와 passwordConfirmation이 같아야 합니다 (controller에서 검증)
- password를 수정하는 경우에는 새로운 password를 hash 해서 DB에 저장합니다

검증이 좀 까다로웠습니다.. 

## 테스트 코드

```
### 내 정보 수정
PATCH http://localhost:3000/users/me
Authorization: Bearer <로그인 시 받은 accessToken>
Content-Type: application/json

{
	"phoneNumber": "010-0000-0000",
	"currentPassword": "password1234", 
	"password": "password12345",
	"passwordConfirmation": "password12345",
	"imageUrl": "example.com"
}