### PR TITLE
feat:customers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "csv-parse": "^5.6.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-jwt": "^8.5.1",
@@ -1203,6 +1204,12 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "csv-parse": "^5.6.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-jwt": "^8.5.1",

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import * as customerService from '../services/customerService';
+import BadRequestError from '../lib/errors/badRequestError';
 
 export const createCustomerHandler = async (req: Request, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
@@ -40,4 +41,14 @@ export const getCustomersHandler = async (req: Request, res: Response) => {
   );
 
   res.status(200).json(result);
+};
+
+export const bulkUploadCustomersHandler = async (req: Request, res: Response) => {
+  const companyId = (req.user as { companyId: number }).companyId;
+  const fileBuffer = req.file?.buffer;
+
+  if (!fileBuffer) throw new BadRequestError('CSV 파일을 업로드해주세요');
+
+  const message = await customerService.bulkUploadCustomers(companyId, fileBuffer);
+  res.status(200).json({ message });
 };

--- a/src/routers/customerRouter.ts
+++ b/src/routers/customerRouter.ts
@@ -1,11 +1,20 @@
 import express from 'express';
 import { asyncHandler } from '../lib/async-handler';
+import upload from '../middlewares/uploadMiddleware';
+import { verifyAccessToken } from '../middlewares/verifyAccessToken';
 import * as customerController from '../controllers/customerController';
+
 const router = express.Router();
 
 router.post('/', asyncHandler(customerController.createCustomerHandler));
 router.patch('/:id', asyncHandler(customerController.updateCustomerHandler));
 router.delete('/:id', asyncHandler(customerController.deleteCustomerHandler));
 router.get('/', asyncHandler(customerController.getCustomersHandler));
+router.post(
+  '/upload',
+  verifyAccessToken,
+  upload.single('file'),
+  asyncHandler(customerController.bulkUploadCustomersHandler),
+);
 
 export default router;


### PR DESCRIPTION
# 주요 사항
## 로직 흐름
- 프론트에서 CSV 파일을 업로드
- 백엔드에서 verifyAccessToken으로 인증
- uploadMiddleware를 통해 파일을 req.file.buffer로 받아옴 
- 서비스에서 CSV 데이터를 csv parse로 파싱
- LABEL(한글)을 ENUM(영문)으로 변환
- createMany로 고객 여러 명 DB에 저장

이외에 응답 메세지 일부 수정

# 커밋 내용
fixed file: customerRouter.ts, customerController.ts, customerService.ts 대용량 업로드 구현 npm parse 이용
