### PR TITLE
feat:dashboard 대시보드 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import customerRouter from './routers/customerRouter';
 import path from 'path';
 import { PUBLIC_PATH, STATIC_PATH } from './lib/constants';
 import imageRouter from './routers/imageRouter';
+import dashboardRouter from './routers/dashboardRouter';
 
 const app: express.Application = express();
 app.use(express.json());
@@ -25,6 +26,7 @@ app.use('/contractDocuments', contractDocumentRouter);
 app.use('/customers', customerRouter);
 app.use('/auth', authRouter);
 app.use('/images', imageRouter);
+app.use('/dashboard', dashboardRouter);
 
 app.use(defaultNotFoundHandler);
 app.use(globalErrorHandler);

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+import * as dashboardService from '../services/dashboardService';
+
+export const getDashboardStatsHandler = async (req: Request, res: Response) => {
+  const companyId = (req.user as { companyId: number }).companyId;
+  const stats = await dashboardService.getDashboardStats(companyId);
+  res.status(200).json(stats);
+};

--- a/src/routers/dashboardRouter.ts
+++ b/src/routers/dashboardRouter.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { asyncHandler } from '../lib/async-handler';
+import { verifyAccessToken } from '../middlewares/verifyAccessToken';
+import * as dashboardController from '../controllers/dashboardController';
+
+const router = express.Router();
+
+router.get('/', verifyAccessToken, asyncHandler(dashboardController.getDashboardStatsHandler));
+
+export default router;

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,106 @@
+import { prisma } from '../lib/prisma';
+
+export const getDashboardStats = async (companyId: number) => {
+  const now = new Date();
+  const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+
+  const [
+    monthlySales,
+    lastMonthSales,
+    proceedingContractsCount,
+    completedContractsCount,
+    contracts,
+    sales,
+  ] = await Promise.all([
+    prisma.contract.aggregate({
+      _sum: { contractPrice: true },
+      where: {
+        companyId,
+        resolutionDate: { gte: thisMonthStart },
+      },
+    }),
+    prisma.contract.aggregate({
+      _sum: { contractPrice: true },
+      where: {
+        companyId,
+        resolutionDate: {
+          gte: lastMonthStart,
+          lte: lastMonthEnd,
+        },
+      },
+    }),
+    prisma.contract.count({
+      where: {
+        companyId,
+        contractStatus: { not: 'CONTRACT_SUCCESSFUL' },
+      },
+    }),
+    prisma.contract.count({
+      where: {
+        companyId,
+        contractStatus: 'CONTRACT_SUCCESSFUL',
+      },
+    }),
+    prisma.contract.groupBy({
+      by: ['carId'],
+      where: {
+        companyId,
+      },
+      _count: true,
+    }),
+    prisma.contract.groupBy({
+      by: ['carId'],
+      where: {
+        companyId,
+      },
+      _sum: {
+        contractPrice: true,
+      },
+    }),
+  ]);
+
+  const carMap = await prisma.car.findMany({
+    where: { companyId },
+    include: { model: true },
+  });
+
+  const carIdToTypeMap: Record<number, string> = {};
+  carMap.forEach((car) => {
+    carIdToTypeMap[car.id] = car.model.type;
+  });
+
+  const contractsByCarType: Record<string, number> = {};
+  contracts.forEach((group) => {
+    const carType = carIdToTypeMap[group.carId] || '기타';
+    contractsByCarType[carType] = (contractsByCarType[carType] || 0) + group._count;
+  });
+
+  const salesByCarType: Record<string, number> = {};
+  sales.forEach((group) => {
+    const carType = carIdToTypeMap[group.carId] || '기타';
+    salesByCarType[carType] = (salesByCarType[carType] || 0) + (group._sum.contractPrice || 0);
+  });
+
+  const formatGroup = (data: Record<string, number>) =>
+    Object.entries(data).map(([carType, count]) => ({ carType, count }));
+
+  const growthRate = lastMonthSales._sum.contractPrice
+    ? Math.round(
+        (((monthlySales._sum.contractPrice || 0) - lastMonthSales._sum.contractPrice) /
+          lastMonthSales._sum.contractPrice) *
+          100,
+      )
+    : 0;
+
+  return {
+    monthlySales: monthlySales._sum.contractPrice || 0,
+    lastMonthSales: lastMonthSales._sum.contractPrice || 0,
+    growthRate,
+    proceedingContractsCount,
+    completedContractsCount,
+    contractsByCarType: formatGroup(contractsByCarType),
+    salesByCarType: formatGroup(salesByCarType),
+  };
+};


### PR DESCRIPTION
# 주요 사항
## 흐름 및 기능
### 라우터
- 인증 요청
### 컨트롤러
- 로그인한 유저 회사id 추출
- 응답은 클라에 전달
### 서비스
- 계약, 매출, 차 타입 등 쿼리를 promise.all 처리
- Enum, 계산 처리

app.ts에 대시보드 관련하여 라우터 추가했습니다.