### PR TITLE
Fix/request user/#121 (req.user 관련 수정)

### DIFF
--- a/src/controllers/carController.ts
+++ b/src/controllers/carController.ts
@@ -9,8 +9,27 @@ import {
 import { create, StructError } from 'superstruct';
 import { SearchField } from '../dto/carDTO';
 import { IdParamsStruct } from '../structs/commonStruct';
+import { AuthenticatedRequest } from '../types/express';
 
+<<<<<<< HEAD
 export const registerCar = async (req: Request, res: Response): Promise<void> => {
+=======
+// export const registerCar = async (req: Request, res: Response): Promise<void> => {
+//   const data = create(req.body, createCarBodyStruct);
+
+//   if (!req.user) {
+//     res.status(401).json({ message: '로그인이 필요합니다' });
+//   }
+//   const companyId = (req.user as { companyId: number }).companyId;
+
+//   if (!companyId) throw new Error('companyId는 필수입니다.');
+
+//   const registerCars = await carService.registerCar(data, companyId);
+//   res.status(201).json(registerCars);
+// };
+
+export const registerCar = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   let data;
   try {
     data = create(req.body, createCarBodyStruct);
@@ -21,13 +40,35 @@ export const registerCar = async (req: Request, res: Response): Promise<void> =>
     return;
   }
 
+<<<<<<< HEAD
   const companyId = (req.user as { companyId: number }).companyId;
+=======
+  const companyId = req.user.companyId;
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
 
   const registerCars = await carService.registerCar(data, companyId);
   res.status(201).json(registerCars);
 };
 
+<<<<<<< HEAD
 export const updateCar = async (req: Request, res: Response): Promise<void> => {
+=======
+// export const updateCar = async (req: Request, res: Response): Promise<void> => {
+//   const { id } = create(req.params, IdParamsStruct);
+//   const data = create(req.body, updateCarBodyStruct);
+
+//   if (!req.user) {
+//     res.status(401).json({ message: '로그인이 필요합니다' });
+//   }
+//   const companyId = (req.user as { companyId: number }).companyId;
+
+//   if (!companyId) throw new Error('companyId는 필수입니다');
+//   const updatedCar = await carService.updateCar(Number(id), data, companyId);
+//   res.status(200).json(updatedCar);
+// };
+
+export const updateCar = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   let id: number;
   let data: any;
 
@@ -41,20 +82,24 @@ export const updateCar = async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
+<<<<<<< HEAD
   const companyId = (req.user as { companyId: number }).companyId;
+=======
+  const companyId = req.user.companyId;
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
 
   const updatedCar = await carService.updateCar(Number(id), data, companyId);
   res.status(200).json(updatedCar);
 };
 
-export const deleteCar = async (req: Request, res: Response): Promise<void> => {
+export const deleteCar = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { id } = create(req.params, IdParamsStruct);
 
   await carService.deleteCar(Number(id));
   res.status(200).send({ message: '차량 삭제 성공' });
 };
 
-export const getCarList = async (req: Request, res: Response): Promise<void> => {
+export const getCarList = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { page, pageSize, searchBy, keyword } = create(req.query, carFilterStruct);
 
   const carList = await carService.getCarList({
@@ -72,23 +117,41 @@ export const getCarList = async (req: Request, res: Response): Promise<void> => 
   });
 };
 
-export const getCarDetail = async (req: Request, res: Response): Promise<void> => {
+export const getCarDetail = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { id } = create(req.params, IdParamsStruct);
 
   const car = await carService.getCarById(Number(id));
   res.status(200).json(car);
 };
 
+<<<<<<< HEAD
 export const getManufacturerModelList = async (req: Request, res: Response): Promise<void> => {
+=======
+export const getManufacturerModelList = async (
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> => {
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   const data = await carService.getManufacturerModelList();
   res.status(200).json(data);
 };
 
+<<<<<<< HEAD
 export const carCsvUpload = async (req: Request, res: Response): Promise<void> => {
   const path = req.file!.path;
 
   const companyId = (req.user as { companyId: number }).companyId;
 
+=======
+export const carCsvUpload = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  const path = req.file?.path;
+  if (!path) {
+    res.status(400).json({ message: '파일이 없습니다' });
+    return;
+  }
+
+  const companyId = req.user.companyId;
+>>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   await carService.carCsvUpload(path, companyId);
   res.json({ message: 'CSV 업로드 및 차량 등록 완료' });
 };

--- a/src/controllers/carController.ts
+++ b/src/controllers/carController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import * as carService from '../services/carService';
 import {
   carFilterStruct,
@@ -11,25 +11,7 @@ import { SearchField } from '../dto/carDTO';
 import { IdParamsStruct } from '../structs/commonStruct';
 import { AuthenticatedRequest } from '../types/express';
 
-<<<<<<< HEAD
-export const registerCar = async (req: Request, res: Response): Promise<void> => {
-=======
-// export const registerCar = async (req: Request, res: Response): Promise<void> => {
-//   const data = create(req.body, createCarBodyStruct);
-
-//   if (!req.user) {
-//     res.status(401).json({ message: '로그인이 필요합니다' });
-//   }
-//   const companyId = (req.user as { companyId: number }).companyId;
-
-//   if (!companyId) throw new Error('companyId는 필수입니다.');
-
-//   const registerCars = await carService.registerCar(data, companyId);
-//   res.status(201).json(registerCars);
-// };
-
 export const registerCar = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   let data;
   try {
     data = create(req.body, createCarBodyStruct);
@@ -40,35 +22,13 @@ export const registerCar = async (req: AuthenticatedRequest, res: Response): Pro
     return;
   }
 
-<<<<<<< HEAD
-  const companyId = (req.user as { companyId: number }).companyId;
-=======
   const companyId = req.user.companyId;
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
 
   const registerCars = await carService.registerCar(data, companyId);
   res.status(201).json(registerCars);
 };
 
-<<<<<<< HEAD
-export const updateCar = async (req: Request, res: Response): Promise<void> => {
-=======
-// export const updateCar = async (req: Request, res: Response): Promise<void> => {
-//   const { id } = create(req.params, IdParamsStruct);
-//   const data = create(req.body, updateCarBodyStruct);
-
-//   if (!req.user) {
-//     res.status(401).json({ message: '로그인이 필요합니다' });
-//   }
-//   const companyId = (req.user as { companyId: number }).companyId;
-
-//   if (!companyId) throw new Error('companyId는 필수입니다');
-//   const updatedCar = await carService.updateCar(Number(id), data, companyId);
-//   res.status(200).json(updatedCar);
-// };
-
 export const updateCar = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   let id: number;
   let data: any;
 
@@ -82,11 +42,7 @@ export const updateCar = async (req: AuthenticatedRequest, res: Response): Promi
     return;
   }
 
-<<<<<<< HEAD
-  const companyId = (req.user as { companyId: number }).companyId;
-=======
   const companyId = req.user.companyId;
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
 
   const updatedCar = await carService.updateCar(Number(id), data, companyId);
   res.status(200).json(updatedCar);
@@ -124,34 +80,19 @@ export const getCarDetail = async (req: AuthenticatedRequest, res: Response): Pr
   res.status(200).json(car);
 };
 
-<<<<<<< HEAD
-export const getManufacturerModelList = async (req: Request, res: Response): Promise<void> => {
-=======
 export const getManufacturerModelList = async (
   req: AuthenticatedRequest,
   res: Response,
 ): Promise<void> => {
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
   const data = await carService.getManufacturerModelList();
   res.status(200).json(data);
 };
 
-<<<<<<< HEAD
-export const carCsvUpload = async (req: Request, res: Response): Promise<void> => {
+export const carCsvUpload = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const path = req.file!.path;
 
-  const companyId = (req.user as { companyId: number }).companyId;
-
-=======
-export const carCsvUpload = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const path = req.file?.path;
-  if (!path) {
-    res.status(400).json({ message: '파일이 없습니다' });
-    return;
-  }
-
   const companyId = req.user.companyId;
->>>>>>> 00efa7e (fix: req.user가 필수인 AuthenticatedRequest 추가)
+
   await carService.carCsvUpload(path, companyId);
   res.json({ message: 'CSV 업로드 및 차량 등록 완료' });
 };

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -4,8 +4,9 @@ import * as companyService from '../services/companyService';
 import { assert, create } from 'superstruct';
 import { companyFilterStruct, createCompanyBodyStruct } from '../structs/companyStruct';
 import { IdParamsStruct } from '../structs/commonStruct';
+import { AuthenticatedRequest } from '../types/express';
 
-export const createCompany = async (req: Request, res: Response) => {
+export const createCompany = async (req: AuthenticatedRequest, res: Response) => {
   assert(req.body, createCompanyBodyStruct);
   // Todo: superstruct가 던지는 에러 잘 잡히는지 확인 필요
   const { companyName, companyCode } = req.body;
@@ -17,20 +18,20 @@ export const createCompany = async (req: Request, res: Response) => {
   res.status(201).json(company);
 };
 
-export const getCompanyList = async (req: Request, res: Response) => {
+export const getCompanyList = async (req: AuthenticatedRequest, res: Response) => {
   const dto: GetCompanyListDTO = create(req.query, companyFilterStruct);
   const companyList = await companyService.getCompanyList(dto);
   res.status(200).json(companyList);
 };
 
-export const updateCompany = async (req: Request, res: Response) => {
+export const updateCompany = async (req: AuthenticatedRequest, res: Response) => {
   const { id: companyId } = create(req.params, IdParamsStruct);
   const data: CreateUpdateCompanyDTO = create(req.body, createCompanyBodyStruct);
   const updated = await companyService.updateAndGetCompany(companyId, data);
   res.status(200).json(updated);
 };
 
-export const deleteCompany = async (req: Request, res: Response) => {
+export const deleteCompany = async (req: AuthenticatedRequest, res: Response) => {
   const { id: companyId } = create(req.params, IdParamsStruct);
   await companyService.deleteCompany(companyId);
   res.status(200).json({ message: '회사 삭제 성공' });

--- a/src/controllers/contractController.ts
+++ b/src/controllers/contractController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import {
   createContractData,
   getGroupedContractByStatus,
@@ -14,14 +14,11 @@ import { createContractBodyStruct, updateContractBodyStruct } from '../structs/c
 import { create, number } from 'superstruct';
 import { GroupedContractSearchParams } from '../types/contractType';
 import { IdParamsStruct } from '../structs/commonStruct';
+import { AuthenticatedRequest } from '../types/express';
 
-export const createContract = asyncHandler(async (req: Request, res: Response) => {
+export const createContract = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   const { carId, customerId, meetings } = create(req.body, createContractBodyStruct);
   const user = req.user;
-
-  if (!user) {
-    throw new UnauthorizedError('로그인이 필요합니다');
-  }
 
   if (!carId || !customerId || !meetings) {
     throw new BadRequestError('잘못된 요청입니다.');
@@ -45,33 +42,27 @@ export const createContract = asyncHandler(async (req: Request, res: Response) =
   return;
 });
 
-export const getGroupedContracts = asyncHandler(async (req: Request, res: Response) => {
-  const { searchBy, keyword } = req.query;
-  const companyId = req.user?.companyId;
+export const getGroupedContracts = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response) => {
+    const { searchBy, keyword } = req.query;
+    const companyId = req.user.companyId;
 
-  if (!companyId) {
-    throw new UnauthorizedError('로그인이 필요합니다.');
-  }
+    const params: GroupedContractSearchParams = {
+      companyId,
+      searchBy: searchBy as 'customerName' | 'userName' | undefined,
+      keyword: keyword as string | undefined,
+    };
 
-  const params: GroupedContractSearchParams = {
-    companyId,
-    searchBy: searchBy as 'customerName' | 'userName' | undefined,
-    keyword: keyword as string | undefined,
-  };
+    const result = await getGroupedContractByStatus(params);
 
-  const result = await getGroupedContractByStatus(params);
+    res.status(200).json(result);
+  },
+);
 
-  res.status(200).json(result);
-});
-
-export const patchContracts = asyncHandler(async (req: Request, res: Response) => {
+export const patchContracts = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   create(req.params, IdParamsStruct);
   const data = create(req.body, updateContractBodyStruct);
   const user = req.user;
-
-  if (!user) {
-    throw new UnauthorizedError('로그인이 필요합니다.');
-  }
 
   const result = await updateContractData({
     contractId: Number(req.params.id),
@@ -82,27 +73,20 @@ export const patchContracts = asyncHandler(async (req: Request, res: Response) =
   res.status(200).json(result);
 });
 
-export const deleteContract = asyncHandler(async (req: Request, res: Response) => {
+export const deleteContract = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   const { id } = create(req.params, IdParamsStruct);
   const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError('로그인이 필요합니다');
-  }
   await delContract(id, user.userId);
 
   res.status(200).json({ message: '계약 삭제 성공' });
   return;
 });
 
-export const getDetailList = asyncHandler(async (req: Request, res: Response) => {
+export const getDetailList = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   const user = req.user;
   const path = req.path;
   const segments = path.split('/').filter(Boolean);
   const lastSegment = segments[segments.length - 1] as 'cars' | 'customers' | 'users';
-
-  if (!user) {
-    throw new UnauthorizedError('로그인이 필요합니다.');
-  }
 
   const result = await detailList({
     companyId: user.companyId,

--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import NotFoundError from '../lib/errors/notFoundError';
 import {
   uploadContractDocument,
@@ -11,19 +11,15 @@ import fs from 'fs';
 import { create } from 'superstruct';
 import { contractDocumentFilterStruct } from '../structs/contractDocumentStruct';
 import BadRequestError from '../lib/errors/badRequestError';
-import UnauthorizedError from '../lib/errors/unauthorizedError';
+import { AuthenticatedRequest } from '../types/express';
 
 export const uploadContractDocumentController = asyncHandler(
-  async (req: Request, res: Response): Promise<void> => {
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const files = req.files as Express.Multer.File[];
     const user = req.user;
 
     if (!files) {
       throw new NotFoundError('필수 정보가 누락되었습니다.');
-    }
-
-    if (!user) {
-      throw new UnauthorizedError('로그인이 필요합니다.');
     }
 
     const toUploadData = (file: Express.Multer.File) => ({
@@ -42,13 +38,9 @@ export const uploadContractDocumentController = asyncHandler(
 );
 
 export const downloadContractDocumentController = asyncHandler(
-  async (req: Request, res: Response): Promise<void> => {
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const id = parseInt(req.params.id);
     const user = req.user;
-
-    if (!user) {
-      throw new UnauthorizedError('로그인이 필요합니다.');
-    }
 
     const { filePath, fileName } = await downloadContractDocument(user.userId, id);
 
@@ -68,14 +60,9 @@ export const downloadContractDocumentController = asyncHandler(
 );
 
 export const getContractDocumentLists = asyncHandler(
-  async (req: Request, res: Response): Promise<void> => {
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const data = create(req.query, contractDocumentFilterStruct);
     const user = req.user;
-
-    if (!user) {
-      throw new UnauthorizedError('로그인이 필요합니다.');
-    }
-
     if (!data) {
       throw new BadRequestError('잘못된 요청 입니다.');
     }
@@ -94,11 +81,8 @@ export const getContractDocumentLists = asyncHandler(
   },
 );
 
-export const getDrafts = asyncHandler(async (req: Request, res: Response) => {
+export const getDrafts = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError('로그인이 필요합니다.');
-  }
   const data = await getDraftContractDocuments(user.companyId);
   res.json(data);
 });

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -3,6 +3,7 @@ import * as customerService from '../services/customerService';
 import BadRequestError from '../lib/errors/badRequestError';
 import { Customer, Gender, AgeGroup, Region } from '@prisma/client';
 import { toGenderEnum, toAgeGroupEnum, toRegionEnum } from '../types/customerType';
+import { AuthenticatedRequest } from '../types/express';
 
 // 응답용 타입 지정...........
 type CustomerForResponse = {
@@ -31,13 +32,13 @@ function toLowerCaseCustomer(customer: CustomerForResponse) {
 }
 
 //기존
-export const createCustomer = async (req: Request, res: Response) => {
+export const createCustomer = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const customer = await customerService.createCustomer(companyId, req.body);
   res.status(201).json(toLowerCaseCustomer(customer));
 };
 
-export const updateCustomer = async (req: Request, res: Response) => {
+export const updateCustomer = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const customerId = Number(req.params.id);
 
@@ -60,7 +61,7 @@ export const updateCustomer = async (req: Request, res: Response) => {
   res.status(200).json(toLowerCaseCustomer(updated));
 };
 
-export const deleteCustomer = async (req: Request, res: Response) => {
+export const deleteCustomer = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const customerId = Number(req.params.id);
 
@@ -68,7 +69,7 @@ export const deleteCustomer = async (req: Request, res: Response) => {
   res.status(200).json({ message: '고객 삭제 성공' });
 };
 
-export const getCustomer = async (req: Request, res: Response) => {
+export const getCustomer = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
 
   const page = Number(req.query.page) || 1;
@@ -93,7 +94,7 @@ export const getCustomer = async (req: Request, res: Response) => {
   res.status(200).json(loweredResult);
 };
 
-export const getCustomerDetail = async (req: Request, res: Response) => {
+export const getCustomerDetail = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const searchBy = req.query.searchBy as 'name' | 'email';
   const keyword = req.query.keyword as string;
@@ -107,7 +108,7 @@ export const getCustomerDetail = async (req: Request, res: Response) => {
   res.status(200).json(customer);
 };
 
-export const bulkUploadCustomer = async (req: Request, res: Response) => {
+export const bulkUploadCustomer = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const fileBuffer = req.file?.buffer;
 

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import * as dashboardService from '../services/dashboardService';
+import { AuthenticatedRequest } from '../types/express';
 
-export const getDashboardStatsHandler = async (req: Request, res: Response) => {
+export const getDashboardStatsHandler = async (req: AuthenticatedRequest, res: Response) => {
   const companyId = (req.user as { companyId: number }).companyId;
   const stats = await dashboardService.getDashboardStats(companyId);
   res.status(200).json(stats);

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,4 +1,4 @@
-import { Request, RequestHandler, Response } from 'express';
+import { Request, Response } from 'express';
 import * as userService from '../services/userService';
 import {
   CreateUserDTO,
@@ -18,9 +18,8 @@ import {
   updateUserBodyStruct,
   userFilterStruct,
 } from '../structs/userStruct';
-import NotFoundError from '../lib/errors/notFoundError';
-import UnauthorizedError from '../lib/errors/unauthorizedError';
 import { IdParamsStruct } from '../structs/commonStruct';
+import { AuthenticatedRequest } from '../types/express';
 
 export const createUser = async (req: Request, res: Response): Promise<void> => {
   assert(req.body, createUserBodyStruct);
@@ -33,7 +32,7 @@ export const createUser = async (req: Request, res: Response): Promise<void> => 
   res.status(201).json(user);
 };
 
-export const getUserList = async (req: Request, res: Response) => {
+export const getUserList = async (req: AuthenticatedRequest, res: Response) => {
   const dto: GetUserListDTO = create(req.query, userFilterStruct);
   const userList = await userService.getUserList(dto);
   res.status(200).json(userList);
@@ -45,7 +44,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
   res.status(200).json(user);
 };
 
-export const refreshToken = async (req: Request, res: Response): Promise<void> => {
+export const refreshToken = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { refreshToken } = create(req.body, refreshTokenBodyStruct);
   const userId = req.user!.userId;
   const dto: RefreshTokenDTO = { refreshToken, userId };
@@ -53,40 +52,31 @@ export const refreshToken = async (req: Request, res: Response): Promise<void> =
   res.status(200).json(newTokens);
 };
 
-export const getMyInfo = async (req: Request, res: Response): Promise<void> => {
-  if (!req.user) {
-    throw new UnauthorizedError('로그인이 필요합니다');
-  }
+export const getMyInfo = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { userId } = req.user;
   const user: UserProfileDTO = await userService.getMyInfo(userId);
   res.status(200).json(user);
 };
 
-export const updateMyInfo = async (req: Request, res: Response): Promise<void> => {
+export const updateMyInfo = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   assert(req.body, updateUserBodyStruct);
   if (req.body.password !== req.body.passwordConfirmation) {
     throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다');
   }
   const { passwordConfirmation, ...rest } = req.body;
   const data: updateMyInfoDTO = rest;
-  if (!req.user) {
-    throw new UnauthorizedError('로그인이 필요합니다');
-  }
   const { userId } = req.user;
   const user: UserProfileDTO = await userService.updateMyInfo(userId, data);
   res.status(200).json(user);
 };
 
-export const deleteMyAccount = async (req: Request, res: Response): Promise<void> => {
-  if (!req.user) {
-    throw new UnauthorizedError('로그인이 필요합니다');
-  }
+export const deleteMyAccount = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { userId } = req.user;
   await userService.deleteMyAccount(userId);
   res.status(200).json({ message: '유저 삭제 성공' });
 };
 
-export const deleteUser = async (req: Request, res: Response): Promise<void> => {
+export const deleteUser = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { id: userId } = create(req.params, IdParamsStruct);
   await userService.deleteUser(userId);
   res.status(200).json({ message: '유저 삭제 성공' });

--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -1,12 +1,13 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { AuthenticatedRequest } from '../types/express';
 
-export function asyncHandler(
-  handler: (req: Request, res: Response, next: NextFunction) => Promise<void>,
+export function asyncHandler<TReq extends Request = Request>(
+  handler: (req: TReq, res: Response, next: NextFunction) => Promise<void>,
 ): RequestHandler {
   //RequestHandler 추가
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
-      await handler(req, res, next);
+      await handler(req as TReq, res, next);
     } catch (e) {
       next(e);
     }

--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -4,7 +4,6 @@ import { AuthenticatedRequest } from '../types/express';
 export function asyncHandler<TReq extends Request = Request>(
   handler: (req: TReq, res: Response, next: NextFunction) => Promise<void>,
 ): RequestHandler {
-  //RequestHandler 추가
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
       await handler(req as TReq, res, next);

--- a/src/routers/carRouter.ts
+++ b/src/routers/carRouter.ts
@@ -11,6 +11,7 @@ import {
 import { asyncHandler } from '../lib/async-handler';
 import upload from '../middlewares/uploadMiddleware';
 import { verifyAccessToken } from '../middlewares/verifyAccessToken';
+import { AuthenticatedRequest } from '../types/express';
 
 const carRouter = express.Router();
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -13,5 +13,5 @@ declare global {
 }
 
 export type AuthenticatedRequest<T extends Request = Request> = T & {
-  user: UserType;
+  user: { userId: number; companyId: number };
 };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -12,15 +12,6 @@ declare global {
   }
 }
 
-export type AuthenticatedRequest<
-  P = any,
-  ResBody = any,
-  ReqBody = any,
-  ReqQuery = any,
-  Locals = any,
-> = Request<P, ResBody, ReqBody, ReqQuery, Locals> & {
-  user: {
-    userId: number;
-    companyId: number;
-  };
+export type AuthenticatedRequest<T extends Request = Request> = T & {
+  user: UserType;
 };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,5 @@
 import Express from 'express';
+import { Request } from 'express';
 
 declare global {
   namespace Express {
@@ -10,3 +11,16 @@ declare global {
     }
   }
 }
+
+export type AuthenticatedRequest<
+  P = any,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = any,
+  Locals = any,
+> = Request<P, ResBody, ReqBody, ReqQuery, Locals> & {
+  user: {
+    userId: number;
+    companyId: number;
+  };
+};


### PR DESCRIPTION
Request 에는 user가 옵셔널이라 인증인가 미들웨어를 거치고 나서도 req.user가 존재하는지를 계속 중복해서 검사해야하는 오류가 있었습니다. 이를 피하기 위해 AuthenticatedRequest라는 user가 무조건 있다고 보장된 Request 타입을 새로 정의했습니다. 
```
export type AuthenticatedRequest<T extends Request = Request> = T & {
  user: { userId: number; companyId: number };
};

```

이에 따라 AsyncHandler에서는 Request의 제너릭 타입을 통해 Request, AuthenticatedRequest 둘다 받을 수 있게 수정. 
각 controller에서 인증인가 미들웨어를 이미 거친 경우에는 매개변수 타입을 AuthenticatedRequest로 지정해두었습니다. 
if(!req.user) 같은 중복된 검증은 삭제했습니다. 

여러 controller를 건드렸다보니 conflict가 많이 날 것으로 예상합니다. 
그런 경우 로컬 브랜치 (그러니까 작업하고 계신 거) 기준으로 컨플릭트를 해결하시고 
그 후에
1. (req:Request, res:Response) 를 (req:AuthenticatedRequest, res:Response) 로 수정해주시고 
2. if(!req.user) 같은 부분이 있었다면 삭제해주시면 됩니다!
