### PR TITLE
Fix/image/#138 이미지 경로 수정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,9 @@ import { multerErrorHandler } from './lib/multerError';
 const app: express.Application = express();
 app.use(express.json());
 app.use(cors());
-app.use(STATIC_PATH, express.static(path.resolve(process.cwd(), PUBLIC_PATH)));
+app.use(STATIC_PATH, express.static(PUBLIC_PATH)); // 이전에 app.use(STATIC_PATH, express.static(path.resolve(process.cwd(), PUBLIC_PATH))); 이라고 되어있었는데 path.resolve(process.cwd()라는 코드는 이미 변수 PUBLIC_PATH의 값이었음. 잘못 기재되있던 부분 수정
+// 서버 디렉토리 구조가 ./public/uploads/**.png 처럼
+// Express.static('public')으로 /uploads/... 정적 경로를 제공하고 있다면 위 코드가 작동
 
 app.use('/cars', carRoutder);
 app.use('/companies', companyRouter);

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 const ALLOWED_FILE_TYPES = ['image/jpeg', 'image/png', 'image/gif']; // 허용할 파일 형식
 const MAX_FILE_SIZE = LIMIT_FILE_SIZE; // 용량 5 MB
 
-const uploadDir = path.join(__dirname, '../../public'); // 업로드 된 파일을 받아줄 public 폴더가 없다면 생성해줌
+const uploadDir = path.join(__dirname, '../../public/uploads'); // 업로드 된 파일을 받아줄 public/uploads 폴더가 없다면 생성해줌
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }
@@ -23,8 +23,18 @@ export const upload = multer({
     filename(req, file, cb) {
       // filename: 업로드된 파일의 이름을 설정
       const ext = path.extname(file.originalname);
-      const existingName = path.basename(file.originalname, ext);
-      const newFileName = `${existingName}-${Date.now()}${ext}`;
+      const originalBuffer = Buffer.from(file.originalname, 'latin1'); // Buffer로 감싸서 문자열을 버퍼로 바꿈
+      // multer가 파일이름을 latin1(서유럽 인코딩)로 종종 받아오는데 그런경우 Buffer로 감싼 후 utf8로 강제로 디코딩해서 정상적으로 한글 파일명 받아오도록 함
+
+      const decodedName = originalBuffer.toString('utf8'); // 버퍼를 다시 문자열로 변환
+
+      const baseName = path
+        .basename(decodedName, ext)
+        .normalize('NFC') // 	일부 시스템에서 조합형 한글(초성+중성+종성)이 깨지는 걸 방지
+        .replace(/[/\\?%*:|"<>]/g, '') // (특수문자 등)위험 문자 제거, (한글,영어,숫자 가능)
+        .replace(/\s+/g, '_'); // 공백 -> 밑줄
+
+      const newFileName = `${baseName}-${Date.now()}${ext}`; // 원본파일이름-타임스탬프.확장자 형식
       cb(null, newFileName);
     },
   }),
@@ -34,7 +44,6 @@ export const upload = multer({
   },
 
   fileFilter: function (req, file, cb) {
-    // fileFilter: 업로드된 파일의 형식을 필터링
     if (!ALLOWED_FILE_TYPES.includes(file.mimetype)) {
       const error = new BadRequestError('허용되지 않는 파일 형식입니다.');
       return cb(error);
@@ -53,8 +62,14 @@ export async function uploadImage(req: Request, res: Response): Promise<void> {
   if (!req.file) {
     throw new BadRequestError('파일이 없습니다.');
   }
-
+  const imageUrl = `http://${host}/uploads/${encodeURIComponent(req.file.filename)}`;
+  /*이전의 코드
   const filePath = path.join(host, STATIC_PATH, req.file.filename);
-  const fileUrl = `http://${encodeURI(filePath.replace(/\\/g, '/'))}`;
-  res.status(201).json({ fileUrl });
+  const fileUrl = `http://${encodeURI(filePath.replace(/\\/g, '/'))}`
+
+  이 방식은 host, STATIC_PATH를 조합해 만든 경로여서 URL로 변환한 것이기 떄문에 실제 URL이 아니라 경로 기반의 조합이었음.
+
+  프론트엔드에서 `http://localhost:3000/uploads/**` 처럼 원해서 그에 맞게 URL경로로 해석되도록 직접 구성해주는 방식으로 수정.
+  */
+  res.status(201).json({ imageUrl }); // 경로 변수명을 이전엔 fileUrl이라 하였는데 프론트에서 imageUrl로 받을거라 예상하고 코드 작성됨
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,6 @@ import dotenv from 'dotenv';
 import path from 'path';
 dotenv.config();
 
-export const PUBLIC_PATH = path.resolve(process.cwd(), 'public'); // 저장될 로컬 폴더 경로 (절대경로)
-export const STATIC_PATH = '/public'; // 클라이언트가 접근할 수 있는 URL 경로
+export const PUBLIC_PATH = path.resolve(process.cwd(), 'public/uploads'); // 실제 서버 디렉토리 경로, 이전에 'public'라고만 되어있던 부분을 'public/uploads'로 수정(브라우저에 업로드 하는 경로와 부분 일치화)
+export const STATIC_PATH = '/uploads'; // 브라우저에서 접근할 URL prefix, 이전에 '/public'로 되어있었는데 프론트코드에서 '/uploads'로 지정되어 있어서 수정
 export const LIMIT_FILE_SIZE = 5 * 1024 * 1024;

--- a/src/routers/imageRouter.ts
+++ b/src/routers/imageRouter.ts
@@ -5,6 +5,6 @@ import { verifyAccessToken } from '../middlewares/verifyAccessToken';
 
 const imageRouter = express.Router();
 
-imageRouter.post('/upload', upload.single('image'), verifyAccessToken, asyncHandler(uploadImage));
+imageRouter.post('/upload', upload.single('file'), verifyAccessToken, asyncHandler(uploadImage)); // 이전에 upload.single('image')라고 되어있었는데 프론트에서 upload.single('file')로 지정해 있어서 수정
 
 export default imageRouter;


### PR DESCRIPTION
#138 

프론트엔드의 이미지 경로에 맞춰서 백엔드 이미지 경로 수정
한글 파일명을 깨지지 않게 하기 위한 추가 Buffer, 정규표현식 로직 구현

### 변경파일
- src/app.ts
- src/controllers/imageController.ts
- src/lib/constants.ts
- src/routers/imageRouter.ts
