### PR TITLE
bug/customers/hofix 고객 수정이 안되던 버그 수정

### DIFF
--- a/src/lib/utils/customers/customerEnumConverter.ts
+++ b/src/lib/utils/customers/customerEnumConverter.ts
@@ -1,106 +1,79 @@
 import { Gender, AgeGroup, Region } from '@prisma/client';
 
 export function toGenderEnum(label: string): Gender {
+  if (!label) throw new Error('성별 값이 없습니다.');
+  if (label === '남성') return 'MALE';
+  if (label === '여성') return 'FEMALE';
+
   const value = label.trim().toUpperCase();
-  switch (value) {
-    case '남성':
-    case 'MALE':
-      return 'MALE';
-    case '여성':
-    case 'FEMALE':
-      return 'FEMALE';
-    default:
-      throw new Error(`잘못된 성별 값: ${label}`);
-  }
+  if (value === 'MALE' || value === 'FEMALE') return value as Gender;
+
+  throw new Error(`잘못된 성별 값: ${label}`);
 }
 
 export function toAgeGroupEnum(label?: string): AgeGroup {
-  const value = label?.trim().toUpperCase();
-  switch (value) {
-    case '10대':
-    case 'TEENAGER':
-      return 'TEENAGER';
-    case '20대':
-    case 'TWENTIES':
-      return 'TWENTIES';
-    case '30대':
-    case 'THIRTIES':
-      return 'THIRTIES';
-    case '40대':
-    case 'FORTIES':
-      return 'FORTIES';
-    case '50대':
-    case 'FIFTIES':
-      return 'FIFTIES';
-    case '60대':
-    case 'SIXTIES':
-      return 'SIXTIES';
-    case '70대':
-    case 'SEVENTIES':
-      return 'SEVENTIES';
-    case '80대':
-    case 'EIGHTIES':
-      return 'EIGHTIES';
-    default:
-      throw new Error(`잘못된 연령대 값: ${label}`);
+  if (!label) throw new Error('연령대 값이 없습니다.');
+  if (label.endsWith('대')) {
+    const korToEnum: Record<string, AgeGroup> = {
+      '10대': 'TEENAGER',
+      '20대': 'TWENTIES',
+      '30대': 'THIRTIES',
+      '40대': 'FORTIES',
+      '50대': 'FIFTIES',
+      '60대': 'SIXTIES',
+      '70대': 'SEVENTIES',
+      '80대': 'EIGHTIES',
+    };
+    if (!(label in korToEnum)) throw new Error(`잘못된 연령대 한글 값: ${label}`);
+    return korToEnum[label];
   }
+
+  const value = label.trim().toUpperCase();
+  if (
+    [
+      'TEENAGER',
+      'TWENTIES',
+      'THIRTIES',
+      'FORTIES',
+      'FIFTIES',
+      'SIXTIES',
+      'SEVENTIES',
+      'EIGHTIES',
+    ].includes(value)
+  ) {
+    return value as AgeGroup;
+  }
+
+  throw new Error(`잘못된 연령대 값: ${label}`);
 }
 
 export function toRegionEnum(label?: string): Region {
-  const value = label?.trim().toUpperCase();
-  switch (value) {
-    case '서울':
-    case 'SEOUL':
-      return 'SEOUL';
-    case '경기':
-    case 'GYEONGGI':
-      return 'GYEONGGI';
-    case '인천':
-    case 'INCHEON':
-      return 'INCHEON';
-    case '강원':
-    case 'GANGWON':
-      return 'GANGWON';
-    case '충북':
-    case 'CHUNGBUK':
-      return 'CHUNGBUK';
-    case '충남':
-    case 'CHUNGNAM':
-      return 'CHUNGNAM';
-    case '세종':
-    case 'SEJONG':
-      return 'SEJONG';
-    case '대전':
-    case 'DAEJEON':
-      return 'DAEJEON';
-    case '전북':
-    case 'JEONBUK':
-      return 'JEONBUK';
-    case '전남':
-    case 'JEONNAM':
-      return 'JEONNAM';
-    case '광주':
-    case 'GWANGJU':
-      return 'GWANGJU';
-    case '경북':
-    case 'GYEONGBUK':
-      return 'GYEONGBUK';
-    case '경남':
-    case 'GYEONGNAM':
-      return 'GYEONGNAM';
-    case '대구':
-    case 'DAEGU':
-      return 'DAEGU';
-    case '울산':
-    case 'ULSAN':
-      return 'ULSAN';
-    case '부산':
-    case 'BUSAN':
-      return 'BUSAN';
-    case '제주':
-    case 'JEJU':
-      return 'JEJU';
-    default:
-      throw new Error(`잘못된 지역 값: ${label}`);
-  }
+  if (!label) throw new Error('지역 값이 없습니다.');
+  const korToEnum: Record<string, Region> = {
+    서울: 'SEOUL',
+    경기: 'GYEONGGI',
+    인천: 'INCHEON',
+    강원: 'GANGWON',
+    충북: 'CHUNGBUK',
+    충남: 'CHUNGNAM',
+    세종: 'SEJONG',
+    대전: 'DAEJEON',
+    전북: 'JEONBUK',
+    전남: 'JEONNAM',
+    광주: 'GWANGJU',
+    경북: 'GYEONGBUK',
+    경남: 'GYEONGNAM',
+    대구: 'DAEGU',
+    울산: 'ULSAN',
+    부산: 'BUSAN',
+    제주: 'JEJU',
+  };
+
+  if (label in korToEnum) return korToEnum[label];
+
+  const value = label.trim().toUpperCase();
+  const enumValues = Object.values(korToEnum);
+  if (enumValues.includes(value as Region)) return value as Region;
+
+  throw new Error(`잘못된 지역 값: ${label}`);
 }

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -33,11 +33,16 @@ export const updateCustomer = async (
   const customer = await customerRepo.getCustomerById(customerId, companyId);
   if (!customer) throw new NotFoundError('고객을 찾을 수 없습니다.');
 
-  return customerRepo.updateCustomer(
-    customerId,
-    companyId,
-    data as Prisma.CustomerUncheckedUpdateManyInput,
-  );
+  const { genderToLabel, ageGroupToLabel, regionToLabel, ...cleanData } = data as any;
+
+  const converted: Prisma.CustomerUncheckedUpdateManyInput = {
+    ...cleanData,
+    ...(cleanData.gender && { gender: toGenderEnum(cleanData.gender) }),
+    ...(cleanData.ageGroup && { ageGroup: toAgeGroupEnum(cleanData.ageGroup) }),
+    ...(cleanData.region && { region: toRegionEnum(cleanData.region) }),
+  };
+
+  return customerRepo.updateCustomer(customerId, companyId, converted);
 };
 
 export const deleteCustomer = async (customerId: number, companyId: number) => {


### PR DESCRIPTION
## 주요 사항
- 고객 정보 수정이 가능하게 되었습니다.

## 문제 요인
- 프론트에서 gender, ageGroup, region 값을 한글("남성", "30대", "서울") 로 보냄
- 백엔드는 이 값을 enum 타입인 영어 MALE, THIRTIES, SEOUL 로 변환하여 DB에 저장
- 하지만 이미 저장된 데이터를 수정할 때, 프론트에서 함께 보내는 genderToLabel, ageGroupToLabel 등의 표시용 필드가 Prisma.customer.update에 포함되어 스키마에 없는 필드 오류 발생

## 해결 방안
- updateCustomer에서 genderToLabel 등의 비DB 필드들을 제거
- gender, ageGroup, region에 대해서는 한글이면 영어 enum으로 변환한 후 저장
- 불필요한 필드를 제거하고 변환 처리를 추가

## 첨부 이미지
![update1](https://github.com/user-attachments/assets/72b0b0a3-82f4-4d34-bb8b-50bdd30705b0)
![update2](https://github.com/user-attachments/assets/27eb11e9-44f3-428b-b589-f65cf4d5b223)

## 커밋 메세지
bug/customers/hofix
>> fixedFile: customerService.ts, customerEnumConverter.ts